### PR TITLE
fix response status code

### DIFF
--- a/fastapi_healthz/route.py
+++ b/fastapi_healthz/route.py
@@ -24,7 +24,7 @@ def health_check_route(registry: HealthCheckRegistry) -> Callable:
 
     def endpoint() -> JSONResponse:
         res = registry.check()
-        if res["status"] == HealthCheckStatusEnum.UNHEALTHY:
+        if res["status"] == HealthCheckStatusEnum.UNHEALTHY.value:
             return JSONResponse(content=encode_json(res), status_code=500)
         return JSONResponse(content=encode_json(res), status_code=200)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastapi-healthz"
-version = "0.6.0"
+version = "0.6.1"
 description = "A module to have a FastAPI HealthCheck for database, RabbitMQ server, Redis, MongoDB or external URI to validate their healths."
 authors = ["Matteo Cacciola <matteo.cacciola@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
According to https://github.com/matteocacciola/fastapi_healthz/issues/1
res["status"] just has HealthCheckStatusEnum value after dump_model response. Therefore, endpoint response status code is always 200